### PR TITLE
fix: do not panic on nil object

### DIFF
--- a/musttag.go
+++ b/musttag.go
@@ -160,6 +160,9 @@ func run(pass *analysis.Pass, funcs map[string]Func) (any, error) {
 		initialPos := token.NoPos
 		switch arg := arg.(type) {
 		case *ast.Ident: // e.g. json.Marshal(foo)
+			if arg.Obj == nil {
+				return // e.g. json.Marshal(nil)
+			}
 			initialPos = arg.Obj.Pos()
 		case *ast.CompositeLit: // e.g. json.Marshal(struct{}{})
 			initialPos = arg.Pos()

--- a/testdata/src/tests/tests.go
+++ b/testdata/src/tests/tests.go
@@ -468,3 +468,8 @@ func nonStructArgument() {
 	custom.Marshal(0)
 	custom.Unmarshal(nil, &[]int{})
 }
+
+// test for panic with nil object issue: https://github.com/junk1tm/musttag/issues/20
+func nilObject() {
+	json.Marshal(nil)
+}


### PR DESCRIPTION
fix #20 for the panic on `json.Marshal(nil)` code